### PR TITLE
Gestion de l'EmptyComponent

### DIFF
--- a/src/collections/components/search/results/index.tsx
+++ b/src/collections/components/search/results/index.tsx
@@ -111,9 +111,7 @@ export class Results<T> extends React.Component<ResultsProps<T>, void> {
                     ))}
                 </div>
             );
-        }
-
-        if (list.length) {
+        } else {
             return (
                 <div data-focus="results">
                     <StoreList
@@ -127,8 +125,6 @@ export class Results<T> extends React.Component<ResultsProps<T>, void> {
                 </div>
             );
         }
-
-        return null;
     }
 }
 


### PR DESCRIPTION
## Comportement constaté

Dans la recherche avancée, le composant de résultats ne rendait pas sa liste en cas de liste vide (`if (list.length)`).

Du coup le EmptyComponent qui est une props du composant de liste n'était pas pris en compte.

## Comportement attendu

En cas de liste vide, le EmptyComponent passé en props à l'AdvancedSearch doit s'affiché.

## Correction

Cette correction rend la liste même si elle est vide afin qu'elle puisse afficher le EmptyComponent.