### PR TITLE
Corrige le warning React sur BooleanRadio

### DIFF
--- a/src/components/boolean-radio.tsx
+++ b/src/components/boolean-radio.tsx
@@ -28,9 +28,13 @@ export function BooleanRadio({disabled, error, name, onChange, theme: pTheme, va
         <Theme theme={pTheme}>
             {theme => (
                 <>
-                    <RadioGroup name={name} value={value} onChange={onChange} className={theme.radio}>
-                        <RadioButton label={i18next.t("focus.boolean.yes")} value={true} disabled={disabled} />
-                        <RadioButton label={i18next.t("focus.boolean.no")} value={false} disabled={disabled} />
+                    <RadioGroup
+                        name={name}
+                        value={value === true ? "true" : value === false ? "false" : undefined}
+                        onChange={(x: string) => onChange(x === "true")}
+                    >
+                        <RadioButton label={i18next.t("focus.boolean.yes")} value={"true"} disabled={disabled} />
+                        <RadioButton label={i18next.t("focus.boolean.no")} value={"false"} disabled={disabled} />
                     </RadioGroup>
                     {error ? <div>{error}</div> : null}
                 </>


### PR DESCRIPTION
Sur le BooleanRadio, on fournit au RadioButton de React un valeur booléenne, alors qu'il attend une valeur string.
Ceci provoque un warning à l'exécution.

Correction : ajouter une conversion string/boolean sur le value et le onChange.