### PR TITLE
fix: use i18n's native plural system

### DIFF
--- a/src/collections/components/search/summary.tsx
+++ b/src/collections/components/search/summary.tsx
@@ -114,8 +114,7 @@ export class Summary<T> extends React.Component<ListSummaryProps<T>> {
                     <div className={theme.summary}>
                         {/* Nombre de résultats. */}
                         <span className={theme.sentence}>
-                            <strong>{totalCount}&nbsp;</strong>
-                            {i18next.t(`${i18nPrefix}.search.summary.result${plural}`)}
+                            {i18next.t(`${i18nPrefix}.search.summary.result`, {count: totalCount})}
                         </span>
 
                         {/* Texte de recherche. */}

--- a/src/translation/fr.ts
+++ b/src/translation/fr.ts
@@ -63,8 +63,8 @@ export const fr = {
             for: "pour",
             group: "groupé par",
             groups: "groupés par",
-            result: "résultat",
-            results: "résultats",
+            result: "{{count}} résultat",
+            result_plural: "{{count}} résultats",
             sortBy: "triés par"
         }
     },


### PR DESCRIPTION
On voudrait joindre le nombre de résultats à chaîne de traduction pour pouvoir les masquer tous les deux si on le souhaite