### PR TITLE
input date et time avec timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "mobx-react": "5.4.3",
         "mobx-react-lite": "1.2.0",
         "moment": "2.24.0",
+        "moment-timezone": "^0.5.25",
         "numeral": "2.0.6",
         "react": "16.8.6",
         "react-dnd": "7.4.5",

--- a/src/components/input-date.tsx
+++ b/src/components/input-date.tsx
@@ -1,21 +1,21 @@
-import { uniqueId } from "lodash";
-import { action, computed, observable } from "mobx";
-import { observer } from "mobx-react";
+import {uniqueId} from "lodash";
+import {action, computed, observable} from "mobx";
+import {observer} from "mobx-react";
 import moment from "moment-timezone";
 import * as React from "react";
-import { IconButton } from "react-toolbox/lib/button";
-import { DatePickerProps, DatePickerTheme } from "react-toolbox/lib/date_picker";
+import {IconButton} from "react-toolbox/lib/button";
+import {DatePickerProps, DatePickerTheme} from "react-toolbox/lib/date_picker";
 import calendarFactory from "react-toolbox/lib/date_picker/Calendar";
-import { InputTheme } from "react-toolbox/lib/input";
+import {InputTheme} from "react-toolbox/lib/input";
 
-import { Input, InputProps } from "../components";
-import { themr } from "../theme";
+import {Input, InputProps} from "../components";
+import {themr} from "../theme";
 
 import * as styles from "react-toolbox/lib/date_picker/theme.css";
 const Theme = themr("RTDatePicker", styles);
 
-import { Moment } from "moment";
-import { calendar, down, fromRight, input, toggle, up } from "./__style__/input-date.css";
+import {Moment} from "moment";
+import {calendar, down, fromRight, input, toggle, up} from "./__style__/input-date.css";
 
 const Calendar = calendarFactory(IconButton);
 
@@ -87,7 +87,7 @@ export class InputDate extends React.Component<InputDateProps> {
     }
 
     @action
-    componentWillReceiveProps({ value }: InputDateProps) {
+    componentWillReceiveProps({value}: InputDateProps) {
         this.date = this.toMoment(value);
         this.dateText = this.formatDate(value);
     }
@@ -115,12 +115,12 @@ export class InputDate extends React.Component<InputDateProps> {
 
     @computed
     get jsDate() {
-        const { timezoneCode } = this.props
+        const {timezoneCode} = this.props;
         // Vérifie que la timezone existe
         if (timezoneCode && moment.tz.zone(timezoneCode)) {
             return getPickerDate(this.date.toDate(), timezoneCode);
         }
-        const { ISOStringFormat = "utc-midnight" } = this.props;
+        const {ISOStringFormat = "utc-midnight"} = this.props;
         if (ISOStringFormat === "utc-midnight") {
             return new Date(this.date.year(), this.date.month(), this.date.date());
         } else {
@@ -135,7 +135,7 @@ export class InputDate extends React.Component<InputDateProps> {
 
     /** Convertit le texte en objet MomentJS. */
     toMoment(value?: string) {
-        const { ISOStringFormat = "utc-midnight" } = this.props;
+        const {ISOStringFormat = "utc-midnight"} = this.props;
         const m = ISOStringFormat === "utc-midnight" ? moment.utc : moment;
 
         if (isISOString(value)) {
@@ -151,7 +151,7 @@ export class InputDate extends React.Component<InputDateProps> {
 
     /** Formatte la date (ISO String) en entrée selon le format demandé. */
     formatDate(value?: string) {
-        const { inputFormat = "MM/DD/YYYY" } = this.props;
+        const {inputFormat = "MM/DD/YYYY"} = this.props;
         if (isISOString(value)) {
             // Le format d'ISO String n'importe peu, ça revient au même une fois formatté.
             return moment(value, moment.ISO_8601).format(inputFormat);
@@ -162,7 +162,7 @@ export class InputDate extends React.Component<InputDateProps> {
 
     /** Ferme le calendrier lorsqu'on clic à l'extérieur du picker. */
     @action.bound
-    onDocumentClick({ target }: Event) {
+    onDocumentClick({target}: Event) {
         let parent = target as HTMLElement | null;
 
         while (parent && parent.getAttribute("data-id") !== this._inputDateId) {
@@ -178,7 +178,7 @@ export class InputDate extends React.Component<InputDateProps> {
     /** Appelé lorsqu'on quitte le champ texte. */
     @action.bound
     onInputBlur() {
-        const { inputFormat = "MM/DD/YYYY", onChange } = this.props;
+        const {inputFormat = "MM/DD/YYYY", onChange} = this.props;
         const text = (this.dateText || "").trim() || undefined;
 
         const date = this.transformDate(text, inputFormat, true);
@@ -194,7 +194,7 @@ export class InputDate extends React.Component<InputDateProps> {
     /** Au clic sur le calendrier. */
     @action.bound
     onCalendarChange(date: Date, dayClick: boolean) {
-        const { ISOStringFormat = "utc-midnight", timezoneCode } = this.props;
+        const {ISOStringFormat = "utc-midnight", timezoneCode} = this.props;
         // Vérifie que la timezone existe
         if (timezoneCode && moment.tz.zone(timezoneCode)) {
             date = getTimezoneTime(this.date.toDate(), timezoneCode);
@@ -217,7 +217,7 @@ export class InputDate extends React.Component<InputDateProps> {
 
     /** Ferme le calendrier lorsqu'on appuie sur Entrée ou Tab. */
     @action.bound
-    handleKeyDown({ key }: KeyboardEvent) {
+    handleKeyDown({key}: KeyboardEvent) {
         if (key === "Tab" || key === "Enter") {
             this.showCalendar = false;
             this.onInputBlur();
@@ -228,7 +228,7 @@ export class InputDate extends React.Component<InputDateProps> {
     transformDate(date: Date): Moment; // Depuis le calendrier.
     transformDate(date: string | undefined, inputFormat: string, strict: true): Moment; // Depuis la saisie manuelle.
     transformDate(...params: any[]) {
-        const { ISOStringFormat = "utc-midnight" } = this.props;
+        const {ISOStringFormat = "utc-midnight"} = this.props;
 
         // Dans les deux cas, la date d'entrée est bien en "local-midnight".
         if (ISOStringFormat === "local-midnight") {
@@ -256,7 +256,7 @@ export class InputDate extends React.Component<InputDateProps> {
                     <div data-focus="input-date" data-id={this._inputDateId} className={input}>
                         <Input
                             {...inputProps}
-                            mask={{ pattern: inputFormat.replace(/\w/g, "1") }}
+                            mask={{pattern: inputFormat.replace(/\w/g, "1")}}
                             onChange={(value: string) => (this.dateText = value)}
                             onKeyDown={this.handleKeyDown}
                             onFocus={() => (this.showCalendar = true)}
@@ -268,7 +268,7 @@ export class InputDate extends React.Component<InputDateProps> {
                                 ref={cal => (this.calendar = cal)}
                                 className={`${calendar} ${displayFrom === "right" ? fromRight : ""} ${
                                     this.calendarPosition === "up" ? up : down
-                                    }`}
+                                }`}
                             >
                                 <header
                                     className={`${theme!.header} ${(theme as any)[`${this.calendarDisplay}Display`]}`}
@@ -292,7 +292,7 @@ export class InputDate extends React.Component<InputDateProps> {
                                     </h3>
                                     <IconButton
                                         icon="clear"
-                                        theme={{ toggle }}
+                                        theme={{toggle}}
                                         onClick={() => (this.showCalendar = false)}
                                     />
                                 </header>
@@ -338,7 +338,7 @@ function getPickerDate(tzDate: Date, timezoneCode: string) {
     pickerDate.setTime(utcDate.getTime() + pickerOffset * 60000);
 
     return pickerDate;
-};
+}
 
 /** Détermine la date pour retourné en prenant en compte la timezone */
 function getTimezoneTime(pickerDate: Date, timezoneCode: string) {
@@ -350,4 +350,4 @@ function getTimezoneTime(pickerDate: Date, timezoneCode: string) {
     const tzDate = new Date();
     tzDate.setTime(utcDate.getTime() - tzOffset * 60000);
     return tzDate;
-};
+}

--- a/src/components/input-time.tsx
+++ b/src/components/input-time.tsx
@@ -1,21 +1,21 @@
-import { uniqueId } from "lodash";
-import { action, observable } from "mobx";
-import { observer } from "mobx-react";
+import {uniqueId} from "lodash";
+import {action, observable} from "mobx";
+import {observer} from "mobx-react";
 import moment from "moment-timezone";
 import * as React from "react";
-import { findDOMNode } from "react-dom";
-import { IconButton } from "react-toolbox/lib/button";
-import { InputTheme } from "react-toolbox/lib/input";
-import { TimePickerTheme } from "react-toolbox/lib/time_picker";
+import {findDOMNode} from "react-dom";
+import {IconButton} from "react-toolbox/lib/button";
+import {InputTheme} from "react-toolbox/lib/input";
+import {TimePickerTheme} from "react-toolbox/lib/time_picker";
 import Clock from "react-toolbox/lib/time_picker/Clock";
 
-import { Input, InputProps } from "../components";
-import { themr } from "../theme";
+import {Input, InputProps} from "../components";
+import {themr} from "../theme";
 
 import * as styles from "react-toolbox/lib/time_picker/theme.css";
 const Theme = themr("RTTimePicker", styles);
 
-import { calendar, clock, down, fromRight, input, toggle, up } from "./__style__/input-date.css";
+import {calendar, clock, down, fromRight, input, toggle, up} from "./__style__/input-date.css";
 
 /** Props de l'InputTime. */
 export interface InputTimeProps extends InputProps {
@@ -69,7 +69,7 @@ export class InputTime extends React.Component<InputTimeProps> {
     }
 
     @action
-    componentWillReceiveProps({ value }: InputTimeProps) {
+    componentWillReceiveProps({value}: InputTimeProps) {
         this.time = this.toMoment(value);
         this.timeText = this.formatTime(value);
     }
@@ -116,7 +116,7 @@ export class InputTime extends React.Component<InputTimeProps> {
 
     /** Recupère la date pour le TimePicker */
     getTime() {
-        const { timezoneCode } = this.props;
+        const {timezoneCode} = this.props;
         // Vérifie que la timezone existe
         if (timezoneCode && moment.tz.zone(timezoneCode)) {
             return getPickerTime(this.time.toDate(), timezoneCode);
@@ -126,7 +126,7 @@ export class InputTime extends React.Component<InputTimeProps> {
 
     /** Formatte l'heure (ISO String) en entrée. */
     formatTime(value?: string) {
-        const { inputFormat = "HH:mm" } = this.props;
+        const {inputFormat = "HH:mm"} = this.props;
         if (isISOString(value)) {
             return moment(value, moment.ISO_8601).format(inputFormat);
         } else {
@@ -136,7 +136,7 @@ export class InputTime extends React.Component<InputTimeProps> {
 
     /** Ferme le calendrier lorsqu'on clic à l'extérieur du picker. */
     @action.bound
-    onDocumentClick({ target }: Event) {
+    onDocumentClick({target}: Event) {
         let parent = target as HTMLElement | null;
 
         while (parent && parent.getAttribute("data-id") !== this._inputTimeId) {
@@ -152,7 +152,7 @@ export class InputTime extends React.Component<InputTimeProps> {
     /** Appelé lorsqu'on quitte le champ texte. */
     @action.bound
     onInputBlur() {
-        const { inputFormat = "HH:mm", onChange } = this.props;
+        const {inputFormat = "HH:mm", onChange} = this.props;
         const text = (this.timeText || "").trim() || undefined;
 
         const time = moment(text, inputFormat, true);
@@ -172,7 +172,7 @@ export class InputTime extends React.Component<InputTimeProps> {
     /** Au clic sur l'horloge. */
     @action.bound
     onClockChange(time: Date) {
-        const { timezoneCode } = this.props;
+        const {timezoneCode} = this.props;
         // Vérifie que la timezone existe
         if (timezoneCode && moment.tz.zone(timezoneCode)) {
             time = getTimezoneTime(this.time.toDate(), timezoneCode);
@@ -192,7 +192,7 @@ export class InputTime extends React.Component<InputTimeProps> {
 
     /** Ferme l'horloge lorsqu'on appuie sur Entrée ou Tab. */
     @action.bound
-    handleKeyDown({ key }: KeyboardEvent) {
+    handleKeyDown({key}: KeyboardEvent) {
         if (key === "Tab" || key === "Enter") {
             this.showClock = false;
             this.onInputBlur();
@@ -200,14 +200,14 @@ export class InputTime extends React.Component<InputTimeProps> {
     }
 
     render() {
-        const { theme: pTheme, inputFormat = "HH:mm", displayFrom = "left", ...inputProps } = this.props;
+        const {theme: pTheme, inputFormat = "HH:mm", displayFrom = "left", ...inputProps} = this.props;
         return (
             <Theme theme={pTheme}>
                 {theme => (
                     <div data-focus="input-time" data-id={this._inputTimeId} className={input}>
                         <Input
                             {...inputProps}
-                            mask={{ pattern: inputFormat.replace(/\w/g, "1") }}
+                            mask={{pattern: inputFormat.replace(/\w/g, "1")}}
                             onChange={(value: string) => (this.timeText = value)}
                             onKeyDown={this.handleKeyDown}
                             onFocus={() => (this.showClock = true)}
@@ -219,9 +219,9 @@ export class InputTime extends React.Component<InputTimeProps> {
                                 ref={clo => (this.clock = clo)}
                                 className={`${calendar} ${theme!.dialog} ${
                                     this.clockDisplay === "hours" ? theme!.hoursDisplay : theme!.minutesDisplay
-                                    } ${displayFrom === "right" ? fromRight : ""} ${
+                                } ${displayFrom === "right" ? fromRight : ""} ${
                                     this.clockPosition === "up" ? up : down
-                                    }`}
+                                }`}
                             >
                                 <header className={theme!.header}>
                                     <span
@@ -241,7 +241,7 @@ export class InputTime extends React.Component<InputTimeProps> {
                                     </span>
                                     <IconButton
                                         icon="clear"
-                                        theme={{ toggle }}
+                                        theme={{toggle}}
                                         onClick={() => (this.showClock = false)}
                                     />
                                 </header>
@@ -281,7 +281,7 @@ function getPickerTime(tzDate: Date, timezoneCode: string) {
     pickerDate.setTime(utcDate.getTime() + pickerOffset * 60000);
 
     return pickerDate;
-};
+}
 
 /** Détermine la date pour retourné en prenant en compte la timezone */
 function getTimezoneTime(pickerDate: Date, timezoneCode: string) {
@@ -293,7 +293,7 @@ function getTimezoneTime(pickerDate: Date, timezoneCode: string) {
     const tzDate = new Date();
     tzDate.setTime(utcDate.getTime() - tzOffset * 60000);
     return tzDate;
-};
+}
 
 /** Retourne le parent le plus proche qui est scrollable. */
 function getScrollParent(element: Element, includeHidden = false) {
@@ -304,7 +304,7 @@ function getScrollParent(element: Element, includeHidden = false) {
     if (style.position === "fixed") {
         return document.body;
     }
-    for (let parent: Element | null = element; (parent = parent.parentElement);) {
+    for (let parent: Element | null = element; (parent = parent.parentElement); ) {
         style = getComputedStyle(parent);
         if (excludeStaticParent && style.position === "static") {
             continue;

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -1,12 +1,12 @@
 // Définitions de styles manquants de libraries externes pour pouvoir compiler certains composants.
 
 declare module "smoothscroll-polyfill";
-
+declare module "moment-timezone"
 declare module "react-toolbox/lib/date_picker/theme.css";
 declare module "react-toolbox/lib/time_picker/theme.css";
 
 declare module "react-toolbox/lib/date_picker/Calendar" {
-    import {DatePickerLocale} from "react-toolbox/lib/date_picker";
+    import { DatePickerLocale } from "react-toolbox/lib/date_picker";
 
     interface CalendarProps {
         disabledDates?: Date[];
@@ -54,7 +54,7 @@ declare module "inputmask-core" {
 
     interface InputMaskOptions {
         pattern: string;
-        formatCharacters?: {[key: string]: InputMaskFormatOptions | null};
+        formatCharacters?: { [key: string]: InputMaskFormatOptions | null };
         placeholderChar?: string;
         value?: string;
         selection?: InputMaskSelection;
@@ -70,7 +70,7 @@ declare module "inputmask-core" {
         getRawValue(): string | undefined;
         getValue(): string | undefined;
 
-        setPattern(pattern: string, options?: {selection?: InputMaskSelection; value?: string | undefined}): void;
+        setPattern(pattern: string, options?: { selection?: InputMaskSelection; value?: string | undefined }): void;
         setSelection(selection: InputMaskSelection): void;
         setValue(value: string | undefined): void;
 

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -1,12 +1,12 @@
 // Définitions de styles manquants de libraries externes pour pouvoir compiler certains composants.
 
 declare module "smoothscroll-polyfill";
-declare module "moment-timezone"
+declare module "moment-timezone";
 declare module "react-toolbox/lib/date_picker/theme.css";
 declare module "react-toolbox/lib/time_picker/theme.css";
 
 declare module "react-toolbox/lib/date_picker/Calendar" {
-    import { DatePickerLocale } from "react-toolbox/lib/date_picker";
+    import {DatePickerLocale} from "react-toolbox/lib/date_picker";
 
     interface CalendarProps {
         disabledDates?: Date[];
@@ -54,7 +54,7 @@ declare module "inputmask-core" {
 
     interface InputMaskOptions {
         pattern: string;
-        formatCharacters?: { [key: string]: InputMaskFormatOptions | null };
+        formatCharacters?: {[key: string]: InputMaskFormatOptions | null};
         placeholderChar?: string;
         value?: string;
         selection?: InputMaskSelection;
@@ -70,7 +70,7 @@ declare module "inputmask-core" {
         getRawValue(): string | undefined;
         getValue(): string | undefined;
 
-        setPattern(pattern: string, options?: { selection?: InputMaskSelection; value?: string | undefined }): void;
+        setPattern(pattern: string, options?: {selection?: InputMaskSelection; value?: string | undefined}): void;
         setSelection(selection: InputMaskSelection): void;
         setValue(value: string | undefined): void;
 


### PR DESCRIPTION
Il s'agit de l'ajout d'une props "timezoneCode" dans les composants input-time et input-date qui permettront en cas de besoin de forcer la timezone du timepicker et datepicker qui ne dépendait auparavant que de la timezone du navigateur. 