### PR TITLE
Refonte headerHeight du Scrollable

### DIFF
--- a/packages/layout/src/header/content.tsx
+++ b/packages/layout/src/header/content.tsx
@@ -20,7 +20,7 @@ export interface HeaderContentProps {
 export function HeaderContent(props: HeaderContentProps) {
     const theme = useTheme("header", headerCss, props.theme);
 
-    const {headerHeight, registerIntersect} = useContext(ScrollableContext);
+    const {registerIntersect} = useContext(ScrollableContext);
     const {sticky, setSticky} = useContext(HeaderContext);
 
     const ref = useRef<HTMLDivElement>(null);
@@ -28,7 +28,7 @@ export function HeaderContent(props: HeaderContentProps) {
         if (ref.current) {
             return registerIntersect(ref.current, (ratio: number) => {
                 const contentHeight = ref.current?.clientHeight ?? 0;
-                const visibleContent = ratio === 1 ? contentHeight : ratio * contentHeight - headerHeight;
+                const visibleContent = ratio * contentHeight;
                 const fixedRatio = visibleContent / contentHeight;
                 if (fixedRatio < 0.1 && !sticky) {
                     setSticky(true);
@@ -37,7 +37,7 @@ export function HeaderContent(props: HeaderContentProps) {
                 }
             });
         }
-    }, [headerHeight, sticky]);
+    }, [sticky]);
 
     return (
         <div ref={ref} className={theme.content()}>

--- a/packages/layout/src/header/top-row.tsx
+++ b/packages/layout/src/header/top-row.tsx
@@ -1,4 +1,4 @@
-import {ReactNode, useContext, useLayoutEffect, useRef} from "react";
+import {ReactNode, useContext, useId, useLayoutEffect, useRef} from "react";
 
 import {CSSProp, useTheme} from "@focus4/styling";
 
@@ -19,11 +19,20 @@ export function HeaderTopRow(props: HeaderTopRowProps) {
     const theme = useTheme("header", headerCss, props.theme);
 
     const ref = useRef<HTMLDivElement>(null);
-    const {setHeaderHeight} = useContext(ScrollableContext);
+    const {setHeaderElementHeight} = useContext(ScrollableContext);
+    const id = useId();
 
     useLayoutEffect(() => {
-        setHeaderHeight(ref.current?.clientHeight ?? 0);
-    });
+        const element = ref.current!;
+        const update = () => setHeaderElementHeight(id, element.clientHeight);
+        update();
+        const observer = new ResizeObserver(update);
+        observer.observe(element);
+        return () => {
+            observer.disconnect();
+            setHeaderElementHeight(id, 0);
+        };
+    }, []);
 
     return (
         <div ref={ref} className={theme.topRow()}>

--- a/packages/layout/src/panels/scrollspy-container.tsx
+++ b/packages/layout/src/panels/scrollspy-container.tsx
@@ -86,18 +86,7 @@ export function ScrollspyContainer({
             return sortBy([...state.panels.entries()], [([_, {node}]) => getOffsetTop(node)]);
         },
         get activeItem() {
-            const panels = sortBy(state.sortedPanels, [
-                ([_, {ratio, node}]) => {
-                    const rect = node.getBoundingClientRect();
-                    const headerRatio =
-                        rect.height === 0
-                            ? 1
-                            : !state.headerHeight
-                              ? 0
-                              : Math.min(1, Math.max(0, (state.headerHeight - rect.y) / rect.height));
-                    return headerRatio - (ratio >= 0.95 ? 1 : ratio);
-                }
-            ]);
+            const panels = sortBy(state.sortedPanels, [([_, {ratio}]) => -(ratio >= 0.95 ? 1 : ratio)]);
             return panels[0]?.[0];
         }
     }));

--- a/packages/layout/src/utils/contexts.ts
+++ b/packages/layout/src/utils/contexts.ts
@@ -48,7 +48,7 @@ export const OverlayContext = createContext<{
 
 /** Contexte d'un Scrollable, expose les méthodes associées. */
 export const ScrollableContext = createContext<{
-    /** Hauteur calculée du `HeaderTopRow` (s'il y en a un) */
+    /** Hauteur calculée de l'éventuel header présent dans le `Scrollable`. */
     headerHeight: number;
     /** Niveau d'empilement de scrollable. Celui du `Layout` sera le niveau 0, augmenté pour chaque `Scrollable` posé à l'intérieur. */
     level: number;
@@ -60,14 +60,20 @@ export const ScrollableContext = createContext<{
     portal(node: ReactElement): ReactPortal | null;
     /**
      * Enregistre un observateur d'intersection avec le viewport du Scrollable.
+     *
+     * Si le Scrollable contient un Header, c'est le bas de la partie sticky du header qui est considéré comme le haut du viewport.
      * @param node Le noeud DOM à observer.
      * @param onIntersect Le callback à appeler lors d'une intersection.
      * @returns Le disposer.
      */
     registerIntersect(node: HTMLElement, onIntersect: (ratio: number, isIntersecting: boolean) => void): () => void;
     /** @internal */
-    /** Met à jour la hauteur du `HeaderTopRow` */
-    setHeaderHeight: (height: number) => void;
+    /**
+     * Met à jour `headerHeight` en précisant la hauteur d'un élément du header.
+     * @param id Sert à distinguer l'élément d'éventuels autres éléments du header.
+     * @param height La hauteur en pixels de l'élément.
+     */
+    setHeaderElementHeight: (id: string, height: number) => void;
     /**
      * Scrolle vers la position demandée.
      * @param options Options.
@@ -80,7 +86,7 @@ export const ScrollableContext = createContext<{
     registerIntersect: () => () => {
         /** */
     },
-    setHeaderHeight() {
+    setHeaderElementHeight() {
         /** */
     },
     scrollTo() {


### PR DESCRIPTION
Actuellement, dans le `ScrollspyContainer`, lorsqu'un panneau passe derrière le `Header` mais sans atteindre le haut du viewport, le `registerIntersect` ne se déclenche pas et le panneau reste marqué à tort comme l'item actif. 

Le but de cette évolution est de prendre en compte le `Header` dans le `registerIntersect`, de manière à ce que ce dernier se déclenche dès qu'un élément passe derrière le `Header`, et qu'il renvoie le véritable ratio visible de l'élément (sa partie qui est non seulement dans le viewport mais aussi non cachée par le `Header`).

Au passage, on rend la mise à jour de la taille du header plus souple en donnant la possibilité d'ajouter plusieurs éléments au header, et en mettant à jour leur taille globale dans `headerHeight`.